### PR TITLE
Pd stepsize fix

### DIFF
--- a/morty/pitchdistribution.py
+++ b/morty/pitchdistribution.py
@@ -43,14 +43,16 @@ class PitchDistribution(object):
         else:
             self.ref_freq = np.array(ref_freq)  # force numpy array
 
+    @property
+    def step_size(self):
         # get step size in cents
-        if self.has_hz_bin:
+        if self.has_hz_bin():
             temp_ss = Converter.hz_to_cent(self.bins[1], self.bins[0])
         else:  # has_cent_bin
             temp_ss = self.bins[1] - self.bins[0]
 
         # TEMPORARY FIX: round step_size to one decimal point
-        self.step_size = temp_ss if temp_ss == (round(temp_ss * 10) / 10) \
+        return temp_ss if temp_ss == (round(temp_ss * 10) / 10) \
             else round(temp_ss * 10) / 10
 
     @property

--- a/morty/pitchdistribution.py
+++ b/morty/pitchdistribution.py
@@ -43,8 +43,13 @@ class PitchDistribution(object):
         else:
             self.ref_freq = np.array(ref_freq)  # force numpy array
 
-        # get step_size to one decimal point
-        temp_ss = self.bins[1] - self.bins[0]
+        # get step size in cents
+        if self.has_hz_bin:
+            temp_ss = Converter.hz_to_cent(self.bins[1], self.bins[0])
+        else:  # has_cent_bin
+            temp_ss = self.bins[1] - self.bins[0]
+
+        # TEMPORARY FIX: round step_size to one decimal point
         self.step_size = temp_ss if temp_ss == (round(temp_ss * 10) / 10) \
             else round(temp_ss * 10) / 10
 


### PR DESCRIPTION
The step size of the pitch distribution has been read in the instantiation. This would cause the value to be changed by mistake, which should be dependent on the bin values.

This merge changes the step_size into a property so each time it is called, the value is computed from the bin separation. It also fixes a bug, where the step_sie is computed wrong when the bins of the distribution is in Hz scale.
